### PR TITLE
Add RGAF09UTM20 support

### DIFF
--- a/lib/references.js
+++ b/lib/references.js
@@ -27,6 +27,9 @@ const IGNF = {
   RGM04UTM38S: 4471, // Légal
   // Réunion
   RGR92UTM40S: 2975, // Légal
+  // Martinique et Guadeloupe
+  RGAF09UTM20: 5490, // Légal
+
 }
 
 const corrections = {


### PR DESCRIPTION
Issue related to missing code `RGAF09UTM20` while parsing recent cadastre data